### PR TITLE
fixed: open to activate and add gfg links

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -32,6 +32,45 @@ const fetchData = async function () {
 
 var browser = browser || chrome;
 
+// function to handle changes in the target class
+function handleChildChanges() {
+  console.log("GFG Extention: Child elements changed");
+  // getting the toggle state
+  chrome.storage.local.get("gfgExtensionState", result => {
+    const toggle = result.gfgExtensionState;
+    if (toggle) {
+      console.log("GFG Extention: Toggle is turned on");
+      fetchData().then((data) => {
+        questions = data;
+        activateExtension();
+      });
+    }else{
+      console.log("GFG Extention: Toggle is turned off");
+    }
+  });
+}
+
+const observerConfig = { childList: true, subtree: true };
+
+const targetClassname = "topics-container"; // Targetting this class because it is the parent of all the questions
+
+let noChangesTimer;
+
+// Callback function to handle mutations
+function mutationCallback(mutationsList, observer) {
+  for (const mutation of mutationsList) {
+    if (mutation.type === 'childList' && mutation.target.classList.contains(targetClassname)) {
+      clearTimeout(noChangesTimer);
+      noChangesTimer = setTimeout(handleChildChanges, 1000);
+    }
+  }
+}
+
+const observer = new MutationObserver(mutationCallback);
+
+// Start observing the entire document and its descendants
+observer.observe(document, observerConfig);
+
 // add a listener for message
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.activate === true) {

--- a/manifest.json
+++ b/manifest.json
@@ -9,10 +9,15 @@
         "48": "icons/logo.png",
         "96": "icons/logo-96.png"
     },
+    
+    "permissions": [
+        "storage"
+    ],
 
     "content_scripts": [{
         "matches": ["https://takeuforward.org/strivers-a2z-dsa-course/strivers-a2z-dsa-course-sheet-2/*"],
-        "js": ["content-script.js"]
+        "js": ["content-script.js"],
+        "run_at": "document_end"
     }],
 
     "action":{

--- a/popup.js
+++ b/popup.js
@@ -28,12 +28,14 @@ function onChange(state) {
 
 // called when checkbox is checked
 const activateExtension = () => {
+  chrome.storage.local.set({ gfgExtensionState: true });
   onChange(true);
   window.localStorage.setItem("gfg-extension", "active");
 };
 
 // called when checkbox is unchecked
 const deactivateExtension = () => {
+  chrome.storage.local.set({ gfgExtensionState: false });
   window.localStorage.removeItem("gfg-extension");
   onChange(false);
 };


### PR DESCRIPTION
Fix for issue #1: As the "problems/links" on the striver page is loaded dynamically, not rendered initially. To resolve this, I have used observer that targets the parent container with the class [topics-container]. When its children are updated, the observer triggers a callback function, which in turn calls the handleChange function.

Due to multiple child additions, causing multiple API calls. To handle this, I've used a timeout mechanism. If there are no DOM updates for at least 1000ms, the handleChange function is invoked.